### PR TITLE
fixed access to comparing buttons

### DIFF
--- a/__tests__/professionId.test.jsx
+++ b/__tests__/professionId.test.jsx
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom';
+import { getPage } from 'next-page-tester';
+import { fireEvent, screen } from '@testing-library/react';
+
+describe('Profession Page', () => {
+  it('frontend developer page buttons access', async () => {
+    const { render } = await getPage({
+      route: '/professions/frontend-developer',
+    });
+
+    render();
+
+    fireEvent.click(screen.getByTestId('geekbrains'));
+    expect(screen.getByTestId('html-academy')).not.toBeDisabled();
+    expect(screen.getByTestId('geekbrains')).not.toBeDisabled();
+
+    fireEvent.click(screen.getByTestId('hexlet'));
+    expect(screen.getByTestId('html-academy')).toBeDisabled();
+  });
+});

--- a/pages/professions/[professionId].jsx
+++ b/pages/professions/[professionId].jsx
@@ -44,10 +44,10 @@ const ComparingButton = (props) => {
   const disabled = state.length >= 2;
 
   if (selected) {
-    return <button type="button" onClick={removeFromCompare} className="btn btn-sm btn-outline-secondary">Убрать</button>;
+    return <button type="button" onClick={removeFromCompare} className="btn btn-sm btn-outline-secondary" data-testid={school.id}>Убрать</button>;
   }
 
-  return <button type="button" onClick={addForCompare} disabled={disabled} className="btn btn-sm btn-outline-primary">Добавить</button>;
+  return <button type="button" onClick={addForCompare} disabled={disabled} className="btn btn-sm btn-outline-primary" data-testid={school.id}>Добавить</button>;
 };
 
 const SchoolItem = (props) => {

--- a/pages/professions/[professionId].jsx
+++ b/pages/professions/[professionId].jsx
@@ -84,8 +84,8 @@ const Profession = (props) => {
   const { t } = useTranslation('common');
   const { schools, profession } = props;
   const { query } = useRouter();
-  const initialState = schools.find((s) => s.id === query.school_id) ?? {};
-  const [state, setState] = useState([initialState]);
+  const initialState = schools.find((s) => s.id === query.school_id) ?? [];
+  const [state, setState] = useState([].concat(initialState));
 
   return (
     <BaseLayout>


### PR DESCRIPTION
Обнаружил неверное поведение блокировки кнопок сравнения. При прямом заходе на страницу профессий https://schools.hexlet.io/professions и после выбора определенной профессии нельзя выбрать 2 школы одновременно для сравнения: после выбора одной, остальные кнопки "Добавить" блокируются. Решил проблему другим заданием начального состояния компонента **Profession**.

![Screen Shot 2021-08-06 at 19 16 21](https://user-images.githubusercontent.com/47382770/128541991-7573af7a-c25a-4f55-99eb-042a24939c70.png)
