### PR TITLE
fix commas for listed items, made dark carousel

### DIFF
--- a/pages/schools/[schoolId].jsx
+++ b/pages/schools/[schoolId].jsx
@@ -76,6 +76,14 @@ const DescriptionValue = (props) => {
       );
     case 'supportOptions':
       return <Link href={value.link}>{value.name}</Link>;
+    case 'learningVariants':
+      return value.join(', ');
+    case 'languages':
+      return value.join(', ');
+    case 'paymentMethods':
+      return value.join(', ');
+    case 'accessByPaymentTypes':
+      return value.join(', ');
     default:
       return value.toString();
   }
@@ -170,7 +178,7 @@ const Screenshot = (props) => {
         {t('school.screenshot')}
       </Modal.Header>
       <Modal.Body className="text-center">
-        <Carousel activeIndex={activeScreenshot} onSelect={handleSelect}>
+        <Carousel activeIndex={activeScreenshot} onSelect={handleSelect} variant="dark" indicators={false}>
           {screenshots.map((screenName) => (
             <Carousel.Item key={screenName}>
               <Image layout="responsive" alt={screenName} width="1440" height="900" src={assetsRoutes.screenshotPath(school, screenName)} />


### PR DESCRIPTION
Добавил пробелы после запятых в полях "Варианты оплаты", "Варианты обучения", "Языки обучения" и "Методы оплаты".
Было:
![Снимок экрана 2022-06-15 232636](https://user-images.githubusercontent.com/98415831/173921110-c813aa50-0cf2-469f-8b95-1e32935cbcbd.png)
Стало:
![Снимок экрана 2022-06-15 233055](https://user-images.githubusercontent.com/98415831/173921503-5b650d64-8ab1-4d7b-ab1b-6f67bf6acaf1.png)

Также, по рекомендации Анастасии Бурнышевой сделал чуть более заметными стрелки Prev и Next в карусели скриншотов: 
![Снимок экрана 2022-06-15 233207](https://user-images.githubusercontent.com/98415831/173921717-10627a1c-f5d1-4c45-b514-ad3f4ca95003.png)