### PR TITLE
fix schools title & description

### DIFF
--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -3,7 +3,7 @@
   "titles": {
     "title_professions": "Cравнение онлайн курсов по программированию",
     "title_certain_school": "{{profession}} - сравнение курсов онлайн-школ",
-    "title_school": "{{school}}: профессии, курсы, обучение в {{school}}",
+    "title_school": "Обзор школы {{school}}: профессии, курсы, обучение в {{school}}",
     "title_comparison": "{{profession}}: сравнение {{school_1}} и {{school_2}}, что лучше",
     "title_error_404": "Страница не найдена",
     "title_error_unspecific": "Внутренняя ошибка сервера"
@@ -11,7 +11,7 @@
   "descriptions": {
     "description_professions": "Онлайн сервис для сравнения курсов по программированию от разных школ. Cравнение онлайн курсов по программированию - Hexlet Comparator",
     "description_certain_school": "Обзор курсов по профессии {{profession}} в популярных онлайн-школах - Hexlet Comparator",
-    "description_school": "Обзор курсов от {{school}}. Какие профессии есть в {{school}}, обзор и сравнение онлайн школы",
+    "description_school": "{{school}} - обзор школы",
     "description_comparison": "Сравнение курсов по профессии {{profession}} в онлайн-школах {{school_1}} и {{school_2}}. Куда пойти учиться по профессии {{profession}}"
   },
   "school": {


### PR DESCRIPTION
Поправлен public/locales/ru/common.json: 'titles.title_school' и 'descriptions.description_school' в соответствии с [ТЗ](https://docs.google.com/spreadsheets/d/1stjgQsXN-b9ZkP8c51vAEL2WXNKAfR8D7sScVWP55Vo/edit#gid=0)

fixes #162 